### PR TITLE
Take address of private member, not variable passed in

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-05-30  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/RcppGSLForward.h: Take address of private member, not
+	variable passed in
+
 2014-05-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION: Version 0.2.1

--- a/inst/include/RcppGSLForward.h
+++ b/inst/include/RcppGSLForward.h
@@ -130,7 +130,7 @@ public:
 	typedef typename vector_view_type<T>::type view_type ;
 	typedef typename vector<T>::Proxy Proxy ;
 	
-	vector_view( view_type view_ ) : view(view_), vector_(&view_.vector) {} 
+	vector_view( view_type view_ ) : view(view_), vector_(&view.vector) {} 
 	inline operator view_type(){ return view ; }
 	inline Proxy operator[]( int i){ 
 		return vector_[i] ;
@@ -154,7 +154,7 @@ public:
 	typedef typename matrix_view_type<T>::type view_type ;
 	typedef typename matrix<T>::Proxy Proxy ;
 	
-	matrix_view( view_type view_ ) : view(view_), matrix_(&view_.matrix) {} 
+	matrix_view( view_type view_ ) : view(view_), matrix_(&view.matrix) {} 
 	inline operator view_type(){ return view; }
 	inline Proxy operator()(int row, int col){
 		return matrix_(row,col);


### PR DESCRIPTION
A very tiny, simple fix for a very hard to uncover problem.

The problem is -- we took the address of a temporary (the object passed into the constructor), rather than the address of the variable stored locally. I guess gcc optimizes in such a way that we get the address of the private member (and everything works), while clang does not.
