### PR TITLE
Simple boolean reference count for data objects 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-07-17  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/macros/RCPPGSL_SPEC.h: Add boolean to check whether
+	'data' remains allocated, and use it to free resources in destructor
+
 2015-07-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION: Release 0.2.5

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppGSL
 Type: Package
 Title: 'Rcpp' Integration for 'GNU GSL' Vectors and Matrices
-Version: 0.2.5
-Date: 2015-07-05
+Version: 0.2.5.1
+Date: 2015-07-17
 Author: Romain Francois and Dirk Eddelbuettel
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: 'Rcpp' integration for 'GNU GSL' vectors and matrices

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,14 @@
 \title{News for Package \pkg{RcppGSL}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 
+\section{Changes in version 0.2.6 (2015-xx-yy)}{
+  \itemize{
+    \item The RcppGSL matrix and vector class now keep track of object
+    allocation and can therefore automatically free allocated object in
+    the destructor. Explicit \code{x.free()} are still supported.
+  }
+}
+
 \section{Changes in version 0.2.5 (2015-07-05)}{
   \itemize{
     \item The \code{colnorm} function in the included example package


### PR DESCRIPTION
This allows for automatic memory management via constructor / destructor rather than forcing the user to call `.free()`