### PR TITLE
Changed constivity of vector_view and matrix_view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: c
 env:
   global:
     - R_BUILD_ARGS="--no-build-vignettes --no-manual"
-    - R_CHECK_ARGS="--no-build-vignettes --no-manual --as-cran"
+    - R_CHECK_ARGS="--no-build-vignettes --no-vignettes --no-manual --as-cran"
     - _R_CHECK_FORCE_SUGGESTS_=FALSE
 
 before_install:

--- a/inst/examples/RcppGSLExample/src/RcppExports.cpp
+++ b/inst/examples/RcppGSLExample/src/RcppExports.cpp
@@ -18,12 +18,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // colNorm
-Rcpp::NumericVector colNorm(RcppGSL::matrix<double> G);
+Rcpp::NumericVector colNorm(const RcppGSL::matrix<double> &G);
 RcppExport SEXP RcppGSLExample_colNorm(SEXP GSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< RcppGSL::matrix<double> >::type G(GSEXP);
+    Rcpp::traits::input_parameter< const RcppGSL::matrix<double> & >::type G(GSEXP);
     __result = Rcpp::wrap(colNorm(G));
     return __result;
 END_RCPP

--- a/inst/examples/RcppGSLExample/src/colNorm.cpp
+++ b/inst/examples/RcppGSLExample/src/colNorm.cpp
@@ -36,7 +36,7 @@ extern "C" SEXP colNorm_old(SEXP sM) {
 		Rcpp::NumericVector n(k); 			// to store results 
 
 		for (int j = 0; j < k; j++) {
-			RcppGSL::vector_view<double> colview = gsl_matrix_column (M, j);
+			RcppGSL::vector_view<double> colview = gsl_matrix_const_column (M, j);
 			n[j] = gsl_blas_dnrm2(colview);
 		}
 		M.free() ;
@@ -61,7 +61,7 @@ Rcpp::NumericVector colNorm_old2(Rcpp::NumericMatrix M) {
     int k = G.ncol();
     Rcpp::NumericVector n(k);           // to store results
     for (int j = 0; j < k; j++) {
-        RcppGSL::vector_view<double> colview = gsl_matrix_column (G, j);
+        RcppGSL::vector_view<double> colview = gsl_matrix_const_column (G, j);
         n[j] = gsl_blas_dnrm2(colview);
     }
     G.free();
@@ -71,11 +71,11 @@ Rcpp::NumericVector colNorm_old2(Rcpp::NumericMatrix M) {
 // newer Attributes-based simplementation with reference counting
 
 // [[Rcpp::export]]
-Rcpp::NumericVector colNorm_old3(RcppGSL::matrix<double> G) {
+Rcpp::NumericVector colNorm_old3(const RcppGSL::matrix<double> &G) {
     int k = G.ncol();
     Rcpp::NumericVector n(k);           // to store results
     for (int j = 0; j < k; j++) {
-        RcppGSL::vector_view<double> colview = gsl_matrix_column (G, j);
+        RcppGSL::vector_view<double> colview = gsl_matrix_const_column (G, j);
         n[j] = gsl_blas_dnrm2(colview);
     }
     return n;                           // return vector
@@ -84,11 +84,11 @@ Rcpp::NumericVector colNorm_old3(RcppGSL::matrix<double> G) {
 // newest version using typedefs
 
 // [[Rcpp::export]]
-Rcpp::NumericVector colNorm(RcppGSL::Matrix G) {
+Rcpp::NumericVector colNorm(const RcppGSL::Matrix &G) {
     int k = G.ncol();
     Rcpp::NumericVector n(k);           // to store results
     for (int j = 0; j < k; j++) {
-        RcppGSL::VectorView colview = gsl_matrix_column (G, j);
+        RcppGSL::VectorView colview = gsl_matrix_const_column (G, j);
         n[j] = gsl_blas_dnrm2(colview);
     }
     return n;                           // return vector

--- a/inst/include/RcppGSLForward.h
+++ b/inst/include/RcppGSLForward.h
@@ -124,53 +124,47 @@ namespace RcppGSL {
 
     template <typename T> class vector_view {
     public:
-        typedef vector<T> VEC;
         typedef typename vector<T>::type type;
-        typedef typename vector<T>::iterator iterator;
         typedef typename vector<T>::const_iterator const_iterator;
         
         typedef typename vector<T>::gsltype gsltype;
         typedef typename vector_view_type<T>::type view_type;
-        typedef typename vector<T>::Proxy Proxy;
+        typedef typename vector<T>::ConstProxy ConstProxy;
         
-        vector_view(view_type view_) : view(view_), vector_(&view.vector) {} 
+        vector_view(view_type view_) : view(view_) {} 
         inline operator view_type() { return view; }
-        inline Proxy operator[](int i) { 
-            return vector_[i];
+        inline ConstProxy operator[](int i) { 
+            return ConstProxy(&view.vector, i);
         }
-        inline iterator begin() { return vector_.begin(); }
-        inline iterator end() { return vector_.end(); }
-        inline const_iterator begin() const { return vector_.begin(); }
-        inline const_iterator end() const { return vector_.end(); }
-        inline size_t size() const { return vector_.size(); }
-        inline operator gsltype*() { return vector_.data; }
+        inline const_iterator begin() const {
+            return const_iterator(ConstProxy(&view.vector, 0));
+        }
+        inline const_iterator end() const {
+            return const_iterator(ConstProxy(&view.vector, view.vector.size));
+        }
+        inline size_t size() const { return view.vector.size; }
+        inline operator const gsltype*() { return &view.vector; }
     
         view_type view;
-    
-    private:
-        VEC vector_;
     };
 
     template <typename T> class matrix_view {
     public:
-        typedef matrix<T> MAT;
         typedef typename matrix<T>::type type;
         typedef typename matrix<T>::gsltype gsltype;
         typedef typename matrix_view_type<T>::type view_type;
-        typedef typename matrix<T>::Proxy Proxy;
+        typedef typename matrix<T>::ConstProxy ConstProxy;
     
-        matrix_view(view_type view_) : view(view_), matrix_(&view.matrix) {} 
+        matrix_view(view_type view_) : view(view_) {} 
         inline operator view_type() { return view; }
-        inline Proxy operator()(int row, int col) {
-            return matrix_(row,col);
+        inline ConstProxy operator()(int row, int col) {
+            return ConstProxy(&view.matrix, row, col);
         }
-        inline size_t nrow() const { return matrix_.nrow(); }              
-        inline size_t ncol() const { return matrix_.ncol(); }              
-        inline size_t size() const { return matrix_.size(); }
-        inline operator gsltype*() { return matrix_.data; }
+        inline size_t nrow() const { return view.matrix.size1; }              
+        inline size_t ncol() const { return view.matrix.size2; }              
+        inline size_t size() const { return view.matrix.size1 * view.matrix.size2; }
+        inline operator gsltype*() { return &view.matrix; }
         view_type view;
-    private:
-        MAT matrix_;
     };
 }
 

--- a/inst/include/RcppGSL_types.h
+++ b/inst/include/RcppGSL_types.h
@@ -201,10 +201,10 @@ private:                                                                \
 
 #define _RCPPGSL_SPEC_NOSUFFIX(__T__,__CAST__)                          \
 template <> struct vector_view_type<__T__> {                            \
-    typedef gsl_vector_view type;                                       \
+    typedef gsl_vector_const_view type;                                 \
 };                                                                      \
 template <> struct matrix_view_type<__T__> {                            \
-    typedef gsl_matrix_view type;                                       \
+    typedef gsl_matrix_const_view type;                                 \
 };                                                                      \
 template <> class vector<__T__>  {           	                        \
 public:                                                                 \

--- a/inst/unitTests/cpp/gsl.cpp
+++ b/inst/unitTests/cpp/gsl.cpp
@@ -315,8 +315,8 @@ List test_gsl_vector_view_wrapper() {
     for( int i=0; i<n; i++){
 	vec[i] = i;
     }
-    RcppGSL::vector_view<double> v_even = gsl_vector_subvector_with_stride(vec, 0, 2, n/2);
-    RcppGSL::vector_view<double> v_odd  = gsl_vector_subvector_with_stride(vec, 1, 2, n/2);
+    RcppGSL::vector_view<double> v_even = gsl_vector_const_subvector_with_stride(vec, 0, 2, n/2);
+    RcppGSL::vector_view<double> v_odd  = gsl_vector_const_subvector_with_stride(vec, 1, 2, n/2);
 
     List res = List::create(_["even"] = v_even,
 			    _["odd" ] = v_odd);
@@ -336,7 +336,7 @@ List test_gsl_matrix_view_wrapper() {
 	    m(i, j) = k;
 	}
     }
-    RcppGSL::matrix_view<double> x = gsl_matrix_submatrix(m, 2, 2, 2, 2 );
+    RcppGSL::matrix_view<double> x = gsl_matrix_const_submatrix(m, 2, 2, 2, 2 );
 
     List res = List::create(_["full"] = m,
 			    _["view"] = x);
@@ -349,7 +349,7 @@ List test_gsl_matrix_view_wrapper() {
 double test_gsl_vector_view_iterating(NumericVector vec_) {
     RcppGSL::vector<double> vec = as< RcppGSL::vector<double> >(vec_);
     int n = vec.size();
-    RcppGSL::vector_view<double> v_even = gsl_vector_subvector_with_stride(vec, 0, 2, n/2);
+    RcppGSL::vector_view<double> v_even = gsl_vector_const_subvector_with_stride(vec, 0, 2, n/2);
     double res = std::accumulate( v_even.begin(), v_even.end(), 0.0 );
     return res;
 }
@@ -365,7 +365,7 @@ double test_gsl_matrix_view_indexing() {
 	    mat(i,j) = k;
 	}
     }
-    RcppGSL::matrix_view<double> x = gsl_matrix_submatrix(mat, 2, 2, 2, 2 );
+    RcppGSL::matrix_view<double> x = gsl_matrix_const_submatrix(mat, 2, 2, 2, 2 );
     double res = 0.0;
     for( size_t i=0; i<x.nrow(); i++){
 	for( size_t j=0; j<x.ncol(); j++){


### PR DESCRIPTION
* `vector_view` ctor now takes a `gsl_vector_const_view` instead of a `gsl_vector_view`
* `vector_view` no longer has a `vector<T>` member.  It gets what it needs from the `gsl_vector_const_view`
* `matrix_view` ctor now takes a `gsl_matrix_const_view` instead of a `gsl_matrix_view`
* `matrix_view` no longer has a `matrix<T>` member.  It gets what it needs from the `gsl_matrix_const_view`
* .travis.yml now passes --no-vignettes to the `R CMD check` step

The practical upshot of all of this is that `vector_view` and `matrix_view` are now completely `const`.  That is to say, you cannot modify a matrix or vector from either of them (which was possible in the past).  Additionally, to construct them you will need to call the `gsl_matrix_const_xxx` and `gsl_vector_const_xxx` functions to get the proper `gsl_xxx_const_view`.