### PR TITLE
Generalized vector_view and matrix_view to be less restrictive

### DIFF
--- a/inst/include/RcppGSLForward.h
+++ b/inst/include/RcppGSLForward.h
@@ -124,15 +124,23 @@ namespace RcppGSL {
 
     template <typename T> class vector_view {
     public:
+        struct internal_view
+        {
+            const gsl_vector vector;
+            
+            inline internal_view(const gsl_vector &v) : vector(v) {}
+        };
+        
         typedef typename vector<T>::type type;
         typedef typename vector<T>::const_iterator const_iterator;
         
         typedef typename vector<T>::gsltype gsltype;
         typedef typename vector_view_type<T>::type view_type;
+        typedef typename vector_view_type<T>::const_type const_view_type;
         typedef typename vector<T>::ConstProxy ConstProxy;
         
-        vector_view(view_type view_) : view(view_) {} 
-        inline operator view_type() { return view; }
+        vector_view(view_type v) : view(v.vector) {}
+        vector_view(const_view_type v) : view(v.vector) {}
         inline ConstProxy operator[](int i) { 
             return ConstProxy(&view.vector, i);
         }
@@ -145,26 +153,35 @@ namespace RcppGSL {
         inline size_t size() const { return view.vector.size; }
         inline operator const gsltype*() { return &view.vector; }
     
-        view_type view;
+        internal_view view;
     };
 
     template <typename T> class matrix_view {
     public:
+        struct internal_view
+        {
+            const gsl_matrix matrix;
+            
+            inline internal_view(const gsl_matrix &m) : matrix(m) {}
+        };
+        
         typedef typename matrix<T>::type type;
         typedef typename matrix<T>::gsltype gsltype;
         typedef typename matrix_view_type<T>::type view_type;
+        typedef typename matrix_view_type<T>::const_type const_view_type;
         typedef typename matrix<T>::ConstProxy ConstProxy;
     
-        matrix_view(view_type view_) : view(view_) {} 
-        inline operator view_type() { return view; }
+        matrix_view(view_type v) : view(v.matrix) {} 
+        matrix_view(const_view_type v) : view(v.matrix) {}
         inline ConstProxy operator()(int row, int col) {
             return ConstProxy(&view.matrix, row, col);
         }
         inline size_t nrow() const { return view.matrix.size1; }              
         inline size_t ncol() const { return view.matrix.size2; }              
         inline size_t size() const { return view.matrix.size1 * view.matrix.size2; }
-        inline operator gsltype*() { return &view.matrix; }
-        view_type view;
+        inline operator const gsltype*() { return &view.matrix; }
+        
+        internal_view view;
     };
 }
 

--- a/inst/include/RcppGSL_types.h
+++ b/inst/include/RcppGSL_types.h
@@ -28,9 +28,11 @@
 #define _RCPPGSL_SPEC(__T__,__SUFFIX__,__CAST__)                        \
 template <> struct vector_view_type<__T__> {                            \
     typedef gsl_vector##__SUFFIX__##_view type;                         \
+    typedef gsl_vector##__SUFFIX__##_const_view const_type;             \
 };                                                                      \
 template <> struct matrix_view_type<__T__> {                            \
     typedef gsl_matrix##__SUFFIX__##_view type;                         \
+    typedef gsl_matrix##__SUFFIX__##_const_view const_type;             \
 };                                                                      \
 template <> class vector<__T__>  {           	                        \
 public:                                                                 \
@@ -201,10 +203,12 @@ private:                                                                \
 
 #define _RCPPGSL_SPEC_NOSUFFIX(__T__,__CAST__)                          \
 template <> struct vector_view_type<__T__> {                            \
-    typedef gsl_vector_const_view type;                                 \
+    typedef gsl_vector_view type;                                       \
+    typedef gsl_vector_const_view const_type;                           \
 };                                                                      \
 template <> struct matrix_view_type<__T__> {                            \
-    typedef gsl_matrix_const_view type;                                 \
+    typedef gsl_matrix_view type;                                       \
+    typedef gsl_matrix_const_view const_type;                           \
 };                                                                      \
 template <> class vector<__T__>  {           	                        \
 public:                                                                 \


### PR DESCRIPTION
Instead of holding a `gsl_xxx_const_view` as a member, `vector_view` and `matrix_view` now hold a look-alike to the `gsl_xxx_const_view` as a member.  This allows them to take either `gsl_xxx_view` or `gsl_xxx_const_view` as parameters to their ctors.  This makes things a bit more flexible and backwards compatible.   It also fixes the build issues we were experiencing with the vignettes.