### PR TITLE
Build against GSL 2.4 on Windows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 vignettes/jss
 vignettes/buildVig.R
 ^local
+^windows$

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/*.so
 src/*.dll
 vignettes/jss/*tex
 vignettes/jss/*R
+windows

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,10 @@
-## This assumes that the LIB_GSL variable points to working GSL libraries
-PKG_CPPFLAGS=-I$(LIB_GSL)/include -I../inst/include
-PKG_LIBS=-L$(LIB_GSL)/lib -lgsl -lgslcblas 
+PKG_CPPFLAGS= -I../windows/gsl-2.4/include -I../inst/include
+PKG_LIBS= -L../windows/gsl-2.4/lib${R_ARCH} -lgsl -lgslcblas
 
+all: clean winlibs
+
+winlibs:
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
+
+clean:
+	rm -f $(SHLIB) $(OBJECTS)

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,7 @@
+# Download GSL 2.4 Rtools build
+if(!file.exists("../windows/gsl-2.4/include/gsl/gsl_blas.h")){
+  download.file("https://github.com/rwinlib/gsl/archive/v2.4.zip", "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
Trying to move away from hardcoded winbuilder stuff. This will build from source out-of-the-box on any Windows machine.